### PR TITLE
feat: add Deepgram transcription script for YouTube videos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
-# OpenAI API Key (required)
+# OpenAI API Key (required for embeddings)
 # Get yours at: https://platform.openai.com/api-keys
 OPENAI_API_KEY=sk-your-key-here
+
+# Deepgram API Key (required for transcription)
+# Get yours at: https://console.deepgram.com/
+DEEPGRAM_API_KEY=your-deepgram-key-here
 
 # Qdrant Configuration
 QDRANT_URL=http://localhost:6333

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ build/
 # Qdrant local storage
 qdrant_storage/
 
+# Downloaded/generated transcripts (keep sample.txt)
+data/transcripts/*.mp3
+data/transcripts/*.json
+data/transcripts/*.srt
+
 # IDE
 .idea/
 .vscode/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,37 +1,141 @@
-# Architecture, v.0.0.1
+# Architecture
 
-## Pipline 
+> High-level system architecture for the Media RAG Pipeline.
 
-### Gathering data diagram 
+## Table of Contents
+
+- [Overview](#overview)
+- [Pipeline](#pipeline)
+  - [Data Ingestion](#data-ingestion)
+  - [Query Flow](#query-flow)
+- [Components](#components)
+  - [Transcription](#transcription)
+  - [Embeddings](#embeddings)
+  - [Vector Database](#vector-database)
+  - [Orchestration](#orchestration)
+
+---
+
+## Overview
+
+The Media RAG Pipeline extracts transcripts from YouTube videos, generates embeddings, stores them in a vector database, and enables semantic search.
+
+```mermaid
+graph LR
+    A[YouTube Video] -->|Deepgram| B[Transcript]
+    B -->|OpenAI| C[Embeddings]
+    C -->|Store| D[(Qdrant)]
+    E[User Query] -->|OpenAI| F[Query Embedding]
+    F -->|Search| D
+    D -->|Results| G[Relevant Chunks]
+```
+
+---
+
+## Pipeline
+
+### Data Ingestion
 
 ```mermaid
 graph TD
-A[Call for model to make embedding] --> B[Put embedding to the vector DB]
+    A[YouTube URL] -->|yt-dlp| B[Audio File]
+    B -->|Deepgram API| C[Transcript + Timestamps]
+    C -->|Text Splitter| D[Chunks]
+    D -->|OpenAI Embeddings| E[Vectors]
+    E -->|Store| F[(Qdrant Collection)]
 ```
 
-### Get the persona notes from the diagram (simplified)
+**Steps:**
+1. Download audio from YouTube using `yt-dlp`
+2. Transcribe with Deepgram (word-level timestamps)
+3. Split transcript into chunks (800 chars, 120 overlap)
+4. Generate embeddings via OpenAI API
+5. Store vectors with metadata in Qdrant
+
+### Query Flow
 
 ```mermaid
 graph TD
-B[transform the user request to embedding] --> C[get the data from the vector DB]
+    A[User Query] -->|OpenAI Embeddings| B[Query Vector]
+    B -->|Similarity Search| C[(Qdrant)]
+    C -->|Top-K Results| D[Relevant Chunks]
+    D -->|Return| E[Text + Metadata]
 ```
 
-## Cloude Models to make embeddings
+**Steps:**
+1. Convert user query to embedding
+2. Search Qdrant for similar vectors
+3. Return top-k chunks with metadata (timestamps, source)
 
-### OpenAI -- Embeddings API
+---
 
-### Cohere - Embed API
+## Components
 
-### Hugging Face Interference API (Sentence-Transformers)
+### Transcription
 
+| Service | Purpose | Status |
+|---------|---------|--------|
+| **Deepgram** | Speech-to-text transcription | Active |
+| yt-dlp | YouTube audio download | Active |
 
-## Vector DBs - self hosted
+**Deepgram Features Used:**
+- Model: `nova-3` (latest)
+- Smart formatting (dates, numbers, emails)
+- Word-level timestamps
+- SRT subtitle generation
+- Optional speaker diarization
 
-### Qdrant(OSS)
+### Embeddings
 
-### Chroma 
+| Provider | Model | Dimensions | Status |
+|----------|-------|------------|--------|
+| **OpenAI** | `text-embedding-3-small` | 1,536 | Active |
+| OpenAI | `text-embedding-3-large` | 3,072 | Available |
+| Cohere | Embed API | - | Planned |
+| Hugging Face | Sentence-Transformers | - | Planned |
 
+### Vector Database
 
-## Intergation tool to handle 
+| Database | Deployment | Status |
+|----------|------------|--------|
+| **Qdrant** | Docker (local) | Active |
+| Chroma | - | Planned |
 
-## LangChain
+**Qdrant Configuration:**
+- Collection: `mentions_mvp`
+- Distance metric: Cosine similarity
+- Ports: 6333 (REST), 6334 (gRPC)
+
+### Orchestration
+
+| Tool | Purpose | Status |
+|------|---------|--------|
+| **LangChain** | Pipeline orchestration | Active |
+| python-dotenv | Environment management | Active |
+
+---
+
+## Directory Structure
+
+```
+media_rag_pipeline/
+├── src/
+│   ├── ingest.py        # Ingest transcripts → Qdrant
+│   ├── query.py         # Query Qdrant
+│   └── transcribe.py    # YouTube → Deepgram → files
+├── data/
+│   └── transcripts/     # Transcripts, SRT, audio
+├── docs/                # Documentation
+└── qdrant_storage/      # Qdrant data (gitignored)
+```
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `OPENAI_API_KEY` | Yes | OpenAI API for embeddings |
+| `DEEPGRAM_API_KEY` | Yes | Deepgram API for transcription |
+| `QDRANT_URL` | No | Qdrant URL (default: localhost:6333) |
+| `QDRANT_COLLECTION` | No | Collection name (default: mentions_mvp) |

--- a/docs/DEEPGRAM_TRANSCRIPTION.md
+++ b/docs/DEEPGRAM_TRANSCRIPTION.md
@@ -108,12 +108,18 @@ export DEEPGRAM_API_KEY="your-key-here"
 
 ### Basic Usage
 
+**From YouTube URL:**
 ```bash
 uv run python src/transcribe.py "https://youtube.com/watch?v=VIDEO_ID"
 ```
 
+**From local audio file:**
+```bash
+uv run python src/transcribe.py --audio-file path/to/audio.mp3
+```
+
 This will:
-1. Download audio from the YouTube video
+1. Download audio from YouTube (or use local file)
 2. Transcribe using Deepgram (Russian language by default)
 3. Save JSON, SRT, and TXT files to `data/transcripts/`
 4. Keep the audio file
@@ -121,14 +127,15 @@ This will:
 ### Command-Line Options
 
 ```
-usage: transcribe.py [-h] [-l LANGUAGE] [-o OUTPUT_DIR] [--diarize]
-                     [--filler-words] [--delete-audio] url
+usage: transcribe.py [-h] [-a AUDIO_FILE] [-l LANGUAGE] [-o OUTPUT_DIR]
+                     [--diarize] [--filler-words] [--delete-audio] [url]
 
 positional arguments:
-  url                   YouTube video URL
+  url                   YouTube video URL (optional if --audio-file provided)
 
 options:
   -h, --help            show this help message and exit
+  -a, --audio-file      Path to local audio file (skip YouTube download)
   -l, --language        Language code (default: ru)
   -o, --output-dir      Output directory (default: data/transcripts)
   --diarize             Enable speaker diarization
@@ -166,6 +173,16 @@ uv run python src/transcribe.py "https://youtube.com/watch?v=VIDEO_ID" -o ./my_t
 **Short URL format:**
 ```bash
 uv run python src/transcribe.py "https://youtu.be/VIDEO_ID"
+```
+
+**From local audio file (already downloaded):**
+```bash
+uv run python src/transcribe.py --audio-file data/transcripts/x5wmGSAmUQA.mp3
+```
+
+**Local file with options:**
+```bash
+uv run python src/transcribe.py -a recording.wav --language en --diarize
 ```
 
 ---

--- a/docs/DEEPGRAM_TRANSCRIPTION.md
+++ b/docs/DEEPGRAM_TRANSCRIPTION.md
@@ -1,0 +1,346 @@
+# Deepgram Transcription Guide
+
+> Transcribe YouTube videos to text using Deepgram API.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Setup](#setup)
+  - [Get Deepgram API Key](#get-deepgram-api-key)
+  - [Install ffmpeg](#install-ffmpeg)
+  - [Configure Environment](#configure-environment)
+- [Usage](#usage)
+  - [Basic Usage](#basic-usage)
+  - [Command-Line Options](#command-line-options)
+  - [Examples](#examples)
+- [Output Files](#output-files)
+  - [JSON Response](#json-response)
+  - [SRT Subtitles](#srt-subtitles)
+  - [Plain Text](#plain-text)
+- [API Features](#api-features)
+- [Troubleshooting](#troubleshooting)
+- [References](#references)
+
+---
+
+## Overview
+
+The transcription script downloads audio from YouTube videos and transcribes them using [Deepgram's](https://deepgram.com/) speech-to-text API.
+
+```mermaid
+graph LR
+    A[YouTube URL] -->|yt-dlp| B[Audio .mp3]
+    B -->|Deepgram API| C[JSON Response]
+    C -->|deepgram-captions| D[SRT Subtitles]
+    C -->|extract| E[Plain Text]
+```
+
+**Why Deepgram?**
+- Fast and accurate transcription
+- Word-level timestamps
+- Speaker diarization support
+- Smart formatting (dates, numbers, emails)
+- Multiple language support
+
+---
+
+## Prerequisites
+
+| Requirement | Purpose |
+|-------------|---------|
+| Deepgram API key | Authentication |
+| ffmpeg | Audio extraction from video |
+| Python 3.12+ | Runtime |
+| uv | Package manager |
+
+---
+
+## Setup
+
+### Get Deepgram API Key
+
+1. Go to [console.deepgram.com](https://console.deepgram.com/)
+2. Sign up or log in
+3. Navigate to **API Keys**
+4. Create a new API key
+5. Copy the key (it won't be shown again)
+
+### Install ffmpeg
+
+ffmpeg is required for extracting audio from YouTube videos.
+
+**macOS (Homebrew):**
+```bash
+brew install ffmpeg
+```
+
+**Ubuntu/Debian:**
+```bash
+sudo apt update && sudo apt install ffmpeg
+```
+
+**Verify installation:**
+```bash
+ffmpeg -version
+```
+
+### Configure Environment
+
+Add your Deepgram API key to `.env`:
+
+```bash
+# Copy the example file
+cp .env.example .env
+
+# Edit and add your key
+echo "DEEPGRAM_API_KEY=your-key-here" >> .env
+```
+
+Or export directly:
+```bash
+export DEEPGRAM_API_KEY="your-key-here"
+```
+
+---
+
+## Usage
+
+### Basic Usage
+
+```bash
+uv run python src/transcribe.py "https://youtube.com/watch?v=VIDEO_ID"
+```
+
+This will:
+1. Download audio from the YouTube video
+2. Transcribe using Deepgram (Russian language by default)
+3. Save JSON, SRT, and TXT files to `data/transcripts/`
+4. Keep the audio file
+
+### Command-Line Options
+
+```
+usage: transcribe.py [-h] [-l LANGUAGE] [-o OUTPUT_DIR] [--diarize]
+                     [--filler-words] [--delete-audio] url
+
+positional arguments:
+  url                   YouTube video URL
+
+options:
+  -h, --help            show this help message and exit
+  -l, --language        Language code (default: ru)
+  -o, --output-dir      Output directory (default: data/transcripts)
+  --diarize             Enable speaker diarization
+  --filler-words        Include filler words like 'um', 'uh'
+  --delete-audio        Delete audio file after transcription
+```
+
+### Examples
+
+**Transcribe Russian video (default):**
+```bash
+uv run python src/transcribe.py "https://youtube.com/watch?v=VIDEO_ID"
+```
+
+**Transcribe English video:**
+```bash
+uv run python src/transcribe.py "https://youtube.com/watch?v=VIDEO_ID" --language en
+```
+
+**With speaker diarization (for interviews/podcasts):**
+```bash
+uv run python src/transcribe.py "https://youtube.com/watch?v=VIDEO_ID" --diarize
+```
+
+**Delete audio after transcription (save space):**
+```bash
+uv run python src/transcribe.py "https://youtube.com/watch?v=VIDEO_ID" --delete-audio
+```
+
+**Custom output directory:**
+```bash
+uv run python src/transcribe.py "https://youtube.com/watch?v=VIDEO_ID" -o ./my_transcripts
+```
+
+**Short URL format:**
+```bash
+uv run python src/transcribe.py "https://youtu.be/VIDEO_ID"
+```
+
+---
+
+## Output Files
+
+For a video with ID `dQw4w9WgXcQ`, the script creates:
+
+| File | Description |
+|------|-------------|
+| `dQw4w9WgXcQ.json` | Full Deepgram API response |
+| `dQw4w9WgXcQ.srt` | SRT subtitle file |
+| `dQw4w9WgXcQ.txt` | Plain text transcript |
+| `dQw4w9WgXcQ.mp3` | Audio file (unless `--delete-audio`) |
+
+### JSON Response
+
+The JSON file contains the complete Deepgram response:
+
+```json
+{
+  "metadata": {
+    "request_id": "...",
+    "duration": 123.45,
+    "channels": 1
+  },
+  "results": {
+    "channels": [{
+      "alternatives": [{
+        "transcript": "Full transcript text...",
+        "confidence": 0.98,
+        "words": [
+          {
+            "word": "hello",
+            "start": 0.0,
+            "end": 0.5,
+            "confidence": 0.99,
+            "punctuated_word": "Hello"
+          }
+        ]
+      }]
+    }],
+    "utterances": [
+      {
+        "start": 0.0,
+        "end": 5.2,
+        "transcript": "Hello, welcome to the video."
+      }
+    ]
+  }
+}
+```
+
+**Key fields:**
+- `words[]`: Word-level timestamps and confidence
+- `utterances[]`: Sentence-level segments (used for SRT)
+- `confidence`: Transcription accuracy score
+
+### SRT Subtitles
+
+Standard SRT format with timestamps:
+
+```srt
+1
+00:00:00,000 --> 00:00:05,200
+Hello, welcome to the video.
+
+2
+00:00:05,500 --> 00:00:10,800
+Today we're going to discuss...
+```
+
+### Plain Text
+
+Clean transcript without timestamps:
+
+```
+Hello, welcome to the video. Today we're going to discuss...
+```
+
+---
+
+## API Features
+
+The script uses these Deepgram API features:
+
+| Feature | Value | Description |
+|---------|-------|-------------|
+| `model` | `nova-3` | Latest, most accurate model |
+| `smart_format` | `true` | Format dates, numbers, emails, URLs |
+| `punctuate` | `true` | Add punctuation |
+| `paragraphs` | `true` | Add paragraph breaks |
+| `utterances` | `true` | Sentence segmentation (for SRT) |
+| `filler_words` | `false` | Remove "um", "uh" by default |
+| `diarize` | `false` | Speaker identification (optional) |
+
+### Language Codes
+
+Common language codes:
+
+| Code | Language |
+|------|----------|
+| `ru` | Russian (default) |
+| `en` | English |
+| `de` | German |
+| `fr` | French |
+| `es` | Spanish |
+| `uk` | Ukrainian |
+
+Full list: [Deepgram Language Support](https://developers.deepgram.com/docs/models-languages-overview)
+
+---
+
+## Troubleshooting
+
+### "DEEPGRAM_API_KEY is not set"
+
+```bash
+# Check if key is set
+echo $DEEPGRAM_API_KEY
+
+# Set it
+export DEEPGRAM_API_KEY="your-key-here"
+
+# Or add to .env file
+echo "DEEPGRAM_API_KEY=your-key-here" >> .env
+```
+
+### "ffmpeg not found"
+
+Install ffmpeg:
+```bash
+# macOS
+brew install ffmpeg
+
+# Ubuntu/Debian
+sudo apt install ffmpeg
+```
+
+### "Could not extract video ID"
+
+Supported URL formats:
+- `https://youtube.com/watch?v=VIDEO_ID`
+- `https://youtu.be/VIDEO_ID`
+- `https://youtube.com/embed/VIDEO_ID`
+- Just the video ID: `VIDEO_ID`
+
+### "Audio file not created"
+
+1. Check internet connection
+2. Verify YouTube URL is valid and video is accessible
+3. Check ffmpeg is installed: `ffmpeg -version`
+4. Try updating yt-dlp: `uv add yt-dlp --upgrade`
+
+### Rate Limits / Quota
+
+If you hit Deepgram rate limits:
+1. Check your usage at [console.deepgram.com](https://console.deepgram.com/)
+2. Add credits if needed
+3. Wait and retry
+
+### Large Files
+
+For long videos (>2 hours):
+- Deepgram has a 2GB file size limit
+- The script extracts audio only (much smaller than video)
+- Consider splitting very long recordings
+
+---
+
+## References
+
+- [Deepgram Documentation](https://developers.deepgram.com/docs/)
+- [Deepgram API Reference](https://developers.deepgram.com/reference/)
+- [Deepgram Python SDK](https://github.com/deepgram/deepgram-python-sdk)
+- [deepgram-python-captions](https://github.com/deepgram/deepgram-python-captions)
+- [yt-dlp Documentation](https://github.com/yt-dlp/yt-dlp)
+- [SRT Format Specification](https://en.wikipedia.org/wiki/SubRip)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 
 - [Architecture](#architecture)
 - [Setup Guides](#setup-guides)
+- [Usage Guides](#usage-guides)
 - [Plans](#plans)
 
 ---
@@ -17,6 +18,10 @@
 - [UV_PYTHON_SETUP.md](./UV_PYTHON_SETUP.md) - Python environment setup with uv package manager
 - [QDRANT_LOCAL_SETUP.md](./QDRANT_LOCAL_SETUP.md) - Setting up Qdrant vector database locally in Docker
 - [OPENAI_EMBEDDINGS_SETUP.md](./OPENAI_EMBEDDINGS_SETUP.md) - Configuring OpenAI API for text embeddings
+
+## Usage Guides
+
+- [DEEPGRAM_TRANSCRIPTION.md](./DEEPGRAM_TRANSCRIPTION.md) - Transcribe YouTube videos using Deepgram API
 
 ## Plans
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,13 @@ description = "RAG pipeline for media transcripts using Qdrant and OpenAI embedd
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "deepgram-captions>=1.2.0",
+    "deepgram-sdk>=5.3.1",
     "langchain>=1.2.6",
     "langchain-openai>=1.1.7",
     "langchain-qdrant>=1.1.0",
     "langchain-text-splitters>=1.1.0",
     "python-dotenv>=1.2.1",
     "qdrant-client>=1.16.2",
+    "yt-dlp>=2025.12.8",
 ]

--- a/src/transcribe.py
+++ b/src/transcribe.py
@@ -26,6 +26,7 @@ import json
 import os
 import re
 import sys
+from datetime import datetime
 from pathlib import Path
 
 import httpx
@@ -202,10 +203,16 @@ def save_results(
     """
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    # Custom JSON encoder for datetime objects
+    def json_serializer(obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
     # Save full JSON response
     json_path = output_dir / f"{video_id}.json"
     with open(json_path, "w", encoding="utf-8") as f:
-        json.dump(response, f, ensure_ascii=False, indent=2)
+        json.dump(response, f, ensure_ascii=False, indent=2, default=json_serializer)
     print(f"JSON saved: {json_path}")
 
     # Extract plain text transcript

--- a/src/transcribe.py
+++ b/src/transcribe.py
@@ -132,7 +132,9 @@ def transcribe_audio(
     print(f"  Filler words: {filler_words}")
     print(f"  Timeout: {timeout}s")
 
-    client = DeepgramClient(api_key=DEEPGRAM_API_KEY)
+    # Create client with custom httpx client for longer timeout
+    http_client = httpx.Client(timeout=httpx.Timeout(timeout, connect=30.0))
+    client = DeepgramClient(api_key=DEEPGRAM_API_KEY, httpx_client=http_client)
 
     with open(audio_path, "rb") as audio_file:
         audio_data = audio_file.read()
@@ -150,7 +152,6 @@ def transcribe_audio(
     mimetype = mimetype_map.get(suffix, "audio/mp3")
 
     # Transcribe with options using v1 API
-    # Use longer timeout for large files
     response = client.listen.v1.media.transcribe_file(
         request=audio_data,
         model="nova-3",
@@ -161,7 +162,6 @@ def transcribe_audio(
         utterances=True,  # Required for SRT generation
         filler_words=filler_words,
         diarize=diarize,
-        timeout=httpx.Timeout(timeout, connect=10.0),
     )
 
     # Convert response to dict

--- a/src/transcribe.py
+++ b/src/transcribe.py
@@ -164,8 +164,25 @@ def transcribe_audio(
         diarize=diarize,
     )
 
-    # Convert response to dict
-    return response.to_dict()
+    # Convert response to dict - handle different SDK versions
+    if hasattr(response, "to_dict"):
+        return response.to_dict()
+    elif hasattr(response, "to_json"):
+        return json.loads(response.to_json())
+    elif hasattr(response, "model_dump"):
+        return response.model_dump()
+    elif hasattr(response, "result"):
+        # v1 API might wrap result
+        result = response.result
+        if hasattr(result, "to_dict"):
+            return result.to_dict()
+        elif hasattr(result, "to_json"):
+            return json.loads(result.to_json())
+    # Fallback: try to access as dict-like or use __dict__
+    try:
+        return dict(response)
+    except (TypeError, ValueError):
+        return response.__dict__
 
 
 def save_results(

--- a/uv.lock
+++ b/uv.lock
@@ -105,6 +105,31 @@ wheels = [
 ]
 
 [[package]]
+name = "deepgram-captions"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/23/6d8aeb10c675b8f30697f0239d8e63b0cc5dc3f861dc7070a3d3eb4ecf12/deepgram-captions-1.2.0.tar.gz", hash = "sha256:2d041b5c84a4438d7b7a633780fee92ecff3c7880721737c8244acd9eb5a7a53", size = 8297, upload-time = "2024-02-07T21:11:00.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/95/795fdd6c99d2e6dfd2478402c25b1087b5129bc970124ce2e4b0571a8c3d/deepgram_captions-1.2.0-py3-none-any.whl", hash = "sha256:fb8c26586fc7f15160644d45f9c5fefec4b1caa375df01d2320599245e03095a", size = 7643, upload-time = "2024-02-07T21:10:59.764Z" },
+]
+
+[[package]]
+name = "deepgram-sdk"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/76/ba0f925f955e171ed789c7f3626251c78786cce09ddc122ac92fe1cc508d/deepgram_sdk-5.3.1.tar.gz", hash = "sha256:87336787c3072d324a0fa412364668adec73175a9f6f0fdd4f91983f734c2842", size = 171393, upload-time = "2026-01-08T14:08:28.617Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/97/af202d6e77403e675d0e48d2a9ccba78437d1537858c9d1667af6d823116/deepgram_sdk-5.3.1-py3-none-any.whl", hash = "sha256:13e9d77552130da51d54c229900b393f96942333ea8e74be0364f8aa8e6afbc5", size = 505950, upload-time = "2026-01-08T14:08:26.574Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -478,22 +503,28 @@ name = "media-rag-pipeline"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "deepgram-captions" },
+    { name = "deepgram-sdk" },
     { name = "langchain" },
     { name = "langchain-openai" },
     { name = "langchain-qdrant" },
     { name = "langchain-text-splitters" },
     { name = "python-dotenv" },
     { name = "qdrant-client" },
+    { name = "yt-dlp" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "deepgram-captions", specifier = ">=1.2.0" },
+    { name = "deepgram-sdk", specifier = ">=5.3.1" },
     { name = "langchain", specifier = ">=1.2.6" },
     { name = "langchain-openai", specifier = ">=1.1.7" },
     { name = "langchain-qdrant", specifier = ">=1.1.0" },
     { name = "langchain-text-splitters", specifier = ">=1.1.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "qdrant-client", specifier = ">=1.16.2" },
+    { name = "yt-dlp", specifier = ">=2025.12.8" },
 ]
 
 [[package]]
@@ -1124,6 +1155,51 @@ wheels = [
 ]
 
 [[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
 name = "xxhash"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1204,6 +1280,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/9a/c19c42c5b3f5a4aad748a6d5b4f23df3bed7ee5445accc65a0fb3ff03953/xxhash-3.6.0-cp314-cp314t-win32.whl", hash = "sha256:5851f033c3030dd95c086b4a36a2683c2ff4a799b23af60977188b057e467119", size = 31586, upload-time = "2025-10-02T14:36:15.603Z" },
     { url = "https://files.pythonhosted.org/packages/03/d6/4cc450345be9924fd5dc8c590ceda1db5b43a0a889587b0ae81a95511360/xxhash-3.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0444e7967dac37569052d2409b00a8860c2135cff05502df4da80267d384849f", size = 32526, upload-time = "2025-10-02T14:36:16.708Z" },
     { url = "https://files.pythonhosted.org/packages/0f/c9/7243eb3f9eaabd1a88a5a5acadf06df2d83b100c62684b7425c6a11bcaa8/xxhash-3.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:bb79b1e63f6fd84ec778a4b1916dfe0a7c3fdb986c06addd5db3a0d413819d95", size = 28898, upload-time = "2025-10-02T14:36:17.843Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2025.12.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/77/db924ebbd99d0b2b571c184cb08ed232cf4906c6f9b76eed763cd2c84170/yt_dlp-2025.12.8.tar.gz", hash = "sha256:b773c81bb6b71cb2c111cfb859f453c7a71cf2ef44eff234ff155877184c3e4f", size = 3088947, upload-time = "2025-12-08T00:16:01.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/2f/98c3596ad923f8efd32c90dca62e241e8ad9efcebf20831173c357042ba0/yt_dlp-2025.12.8-py3-none-any.whl", hash = "sha256:36e2584342e409cfbfa0b5e61448a1c5189e345cf4564294456ee509e7d3e065", size = 3291464, upload-time = "2025-12-08T00:15:58.556Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #11

Add script to transcribe YouTube videos using Deepgram API. Downloads audio with yt-dlp, transcribes with Deepgram, outputs JSON/SRT/TXT.

## Workflow

```mermaid
graph LR
    A[YouTube URL] -->|yt-dlp| B[Audio .mp3]
    B -->|Deepgram API| C[JSON Response]
    C -->|deepgram-captions| D[SRT File]
    C -->|extract| E[TXT File]
```

## CLI Interface

```bash
# Basic usage (Russian, keep audio, no diarization)
uv run python src/transcribe.py "https://youtube.com/watch?v=VIDEO_ID"

# With options
uv run python src/transcribe.py "https://youtube.com/watch?v=VIDEO_ID" \
  --language en \
  --diarize \
  --delete-audio
```

## Options

| Option | Default | Description |
|--------|---------|-------------|
| `--language` / `-l` | `ru` | Language code |
| `--output-dir` / `-o` | `data/transcripts` | Output directory |
| `--diarize` | off | Enable speaker diarization |
| `--filler-words` | off | Include "um", "uh" (removed by default) |
| `--delete-audio` | off | Delete audio after transcription |

## Output Files

For video `dQw4w9WgXcQ`:
- `data/transcripts/dQw4w9WgXcQ.json` - Full Deepgram response
- `data/transcripts/dQw4w9WgXcQ.srt` - Subtitles
- `data/transcripts/dQw4w9WgXcQ.txt` - Plain text
- `data/transcripts/dQw4w9WgXcQ.mp3` - Audio (kept by default)

## Deepgram API Features

| Feature | Value | Purpose |
|---------|-------|---------|
| `model` | `nova-3` | Latest/best model |
| `smart_format` | `true` | Format dates, numbers, emails |
| `punctuate` | `true` | Add punctuation |
| `paragraphs` | `true` | Whitespace formatting |
| `utterances` | `true` | Required for SRT |

## Dependencies Added

```
yt-dlp>=2025.12.8
deepgram-sdk>=5.3.1
deepgram-captions>=1.2.0
```

**System requirement**: `ffmpeg` (for audio extraction)

## Test plan

- [ ] Run `uv run python src/transcribe.py --help` shows usage
- [ ] Download audio from YouTube video
- [ ] Transcribe with Deepgram API
- [ ] Verify JSON contains full response
- [ ] Verify SRT has proper timestamps
- [ ] Verify TXT has plain text
- [ ] Test `--language en` option
- [ ] Test `--diarize` option
- [ ] Test `--delete-audio` option

---

Generated with [Claude Code](https://claude.com/claude-code)