### PR TITLE
feat: add --srt-mode parameter for paragraph-based SRT generation

### DIFF
--- a/docs/DEEPGRAM_TRANSCRIPTION.md
+++ b/docs/DEEPGRAM_TRANSCRIPTION.md
@@ -128,7 +128,8 @@ This will:
 
 ```
 usage: transcribe.py [-h] [-a AUDIO_FILE] [-l LANGUAGE] [-o OUTPUT_DIR]
-                     [--diarize] [--filler-words] [--delete-audio] [url]
+                     [--diarize] [--filler-words] [--delete-audio]
+                     [-t TIMEOUT] [--srt-mode {utterances,paragraphs}] [url]
 
 positional arguments:
   url                   YouTube video URL (optional if --audio-file provided)
@@ -141,7 +142,16 @@ options:
   --diarize             Enable speaker diarization
   --filler-words        Include filler words like 'um', 'uh'
   --delete-audio        Delete audio file after transcription
+  -t, --timeout         API timeout in seconds (default: 600)
+  --srt-mode            SRT generation mode (default: utterances)
 ```
+
+#### SRT Modes
+
+| Mode | Segments | Duration | Best For |
+|------|----------|----------|----------|
+| `utterances` | Many (~1000+) | 1-4 seconds | Word-level precision |
+| `paragraphs` | Fewer (~100-200) | 10-40 seconds | Readable subtitles |
 
 ### Examples
 
@@ -183,6 +193,11 @@ uv run python src/transcribe.py --audio-file data/transcripts/x5wmGSAmUQA.mp3
 **Local file with options:**
 ```bash
 uv run python src/transcribe.py -a recording.wav --language en --diarize
+```
+
+**Generate readable SRT with paragraph-based segments:**
+```bash
+uv run python src/transcribe.py "https://youtube.com/watch?v=VIDEO_ID" --srt-mode paragraphs
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Add `--srt-mode` parameter to choose between `utterances` (default) and `paragraphs` for SRT generation
- Implement custom `generate_srt_from_paragraphs()` function that produces longer, more readable subtitle segments
- Update documentation with new option and SRT modes comparison table

## Problem

The current SRT output uses `utterances` which creates very short segments (1-4 seconds, often fragments):

```srt
3
00:00:12,765 --> 00:00:14,125
В Киеве сейчас

4
00:00:14,205 --> 00:00:16,605
семь часов сорок одна минута
```

## Solution

Use Deepgram's `paragraphs` data for longer, complete segments:

```srt
1
00:00:06,799 --> 00:00:34,539
Доброе утро, дорогие друзья. Меня зовут Игорь Яковенко. Сегодня девятое января...
```

### Comparison

| Mode | Segments | Duration | Content |
|------|----------|----------|---------|
| `utterances` | ~1000+ | 1-4s | Fragments |
| `paragraphs` | ~139 | 10-40s | Complete thoughts |

## Usage

```bash
# Default (utterances)
uv run python src/transcribe.py URL

# Paragraph-based (longer segments)
uv run python src/transcribe.py URL --srt-mode paragraphs
```

## Test plan

- [x] Verify syntax: `python -m py_compile src/transcribe.py`
- [x] Test `format_srt_timestamp()` with various inputs
- [x] Test `generate_srt_from_paragraphs()` with real JSON data
- [ ] Manual test with `--srt-mode paragraphs`

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)