### PR TITLE
feat: add batch endpoint and move NER docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -135,7 +135,7 @@ POST /ner/persons
 → {"persons": ["Иванов", "Петрова"], "has_persons": true}
 ```
 
-See [services/ner/README.md](../services/ner/README.md) for details.
+See [NER_SERVICE.md](./NER_SERVICE.md) for details.
 
 ### Embeddings
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@
 
 ## Services
 
-- [NER Service](../services/ner/README.md) - Russian PERSON-NER microservice for detecting person mentions
+- [NER_SERVICE.md](./NER_SERVICE.md) - Russian PERSON-NER microservice for detecting person mentions
 
 ## Plans
 

--- a/services/ner/app/main.py
+++ b/services/ner/app/main.py
@@ -37,12 +37,26 @@ class NerRequest(BaseModel):
     return_raw: bool = Field(False, description="Return raw NER spans as well")
 
 
+class NerBatchRequest(BaseModel):
+    """Request model for batch NER endpoint."""
+
+    texts: list[str] = Field(..., min_length=1, description="List of Russian text chunks")
+    return_raw: bool = Field(False, description="Return raw NER spans as well")
+
+
 class NerResponse(BaseModel):
     """Response model for NER endpoint."""
 
     persons: list[str]
     has_persons: bool = Field(description="Quick check if any persons were found")
     raw: list[dict[str, Any]] | None = None
+
+
+class NerBatchResponse(BaseModel):
+    """Response model for batch NER endpoint."""
+
+    results: list[NerResponse]
+    total_with_persons: int = Field(description="Count of texts that have persons")
 
 
 class HealthResponse(BaseModel):
@@ -57,6 +71,40 @@ def _is_person(ent: dict[str, Any]) -> bool:
     """Check if entity is a person."""
     label = (ent.get("entity_group") or ent.get("entity") or "").upper()
     return "PER" in label or "PERSON" in label
+
+
+def _extract_persons(text: str, return_raw: bool = False) -> NerResponse:
+    """Extract person entities from a single text.
+
+    Args:
+        text: Russian text to analyze
+        return_raw: Whether to include raw NER spans
+
+    Returns:
+        NerResponse with extracted persons
+    """
+    ents = ner(text)
+
+    persons: list[str] = []
+    for e in ents:
+        if _is_person(e):
+            word = (e.get("word") or "").strip()
+            if word:
+                persons.append(word)
+
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique: list[str] = []
+    for p in persons:
+        if p not in seen:
+            seen.add(p)
+            unique.append(p)
+
+    return NerResponse(
+        persons=unique,
+        has_persons=len(unique) > 0,
+        raw=ents if return_raw else None,
+    )
 
 
 @app.get("/healthz", response_model=HealthResponse)
@@ -80,25 +128,24 @@ def ner_persons(req: NerRequest) -> NerResponse:
         Input: "Иванов раскритиковал Петрова, а Кузнецова похвалил."
         Output: {"persons": ["Иванов", "Петрова", "Кузнецова"], "has_persons": true}
     """
-    ents = ner(req.text)
+    return _extract_persons(req.text, req.return_raw)
 
-    persons: list[str] = []
-    for e in ents:
-        if _is_person(e):
-            word = (e.get("word") or "").strip()
-            if word:
-                persons.append(word)
 
-    # Deduplicate while preserving order
-    seen: set[str] = set()
-    unique: list[str] = []
-    for p in persons:
-        if p not in seen:
-            seen.add(p)
-            unique.append(p)
+@app.post("/ner/persons/batch", response_model=NerBatchResponse)
+def ner_persons_batch(req: NerBatchRequest) -> NerBatchResponse:
+    """Extract person entities from multiple texts.
 
-    return NerResponse(
-        persons=unique,
-        has_persons=len(unique) > 0,
-        raw=ents if req.return_raw else None,
+    This endpoint processes a batch of texts and returns results for each.
+    More efficient than calling /ner/persons multiple times.
+
+    Example:
+        Input: {"texts": ["Иванов met Петров.", "No persons here."], "return_raw": false}
+        Output: {"results": [...], "total_with_persons": 1}
+    """
+    results = [_extract_persons(text, req.return_raw) for text in req.texts]
+    total_with_persons = sum(1 for r in results if r.has_persons)
+
+    return NerBatchResponse(
+        results=results,
+        total_with_persons=total_with_persons,
     )


### PR DESCRIPTION
## Summary

- Add `POST /ner/persons/batch` endpoint for processing multiple texts efficiently
- Move NER documentation from `services/ner/README.md` to `docs/NER_SERVICE.md`
- Update all documentation references

## New Batch Endpoint

### `POST /ner/persons/batch`

Process multiple texts in a single request:

```json
// Request
{
  "texts": ["Иванов met Петров.", "No persons here.", "Сидоров spoke."],
  "return_raw": false
}

// Response
{
  "results": [
    {"persons": ["Иванов", "Петров"], "has_persons": true, "raw": null},
    {"persons": [], "has_persons": false, "raw": null},
    {"persons": ["Сидоров"], "has_persons": true, "raw": null}
  ],
  "total_with_persons": 2
}
```

## Code Changes

- `services/ner/app/main.py`:
  - Add `NerBatchRequest` and `NerBatchResponse` models
  - Extract `_extract_persons()` helper function
  - Add `/ner/persons/batch` endpoint

## Documentation Changes

- Move `services/ner/README.md` → `docs/NER_SERVICE.md`
- Add Table of Contents
- Add batch endpoint documentation
- Update references in `ARCHITECTURE.md` and `README.md`

## Test Plan

- [x] Python syntax check
- [ ] Test single endpoint still works
- [ ] Test batch endpoint with multiple texts
- [ ] Verify documentation links work

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)